### PR TITLE
Don't render on `view-source:` protocol

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+2013-04-25 Zulkarnain K.
+
+    * Don't render on `view-source:` protocol
+
 2013-04-13 Thibaut Rousseau
 
     * Removed the the redirection from filename.md to filename.md?.mdown since this fix doesn't work, the redirect must be done before the page loads

--- a/chrome/content/markdownviewer.js
+++ b/chrome/content/markdownviewer.js
@@ -17,7 +17,7 @@ if (typeof markdownviewer === 'undefined') {
 			var document = aEvent.originalTarget,
 			    regexpMdFile = /\.m(arkdown|kdn?|do?(wn)?)$/i;
 
-			if ((document.location.protocol != 'view-source:') && regexpMdFile.test(document.location)) {
+			if (document.location.protocol != 'view-source:' && regexpMdFile.test(document.location)) {
 				marked.setOptions({
 					gfm: true,
 					pedantic: false,


### PR DESCRIPTION
Example:
[view-source:https://raw.github.com/Thiht/markdown-viewer/master/README.md](view-source:https://raw.github.com/Thiht/markdown-viewer/master/README.md)
