### PR TITLE
Fix regexp to detect markdown file (URL with GET parameters)

### DIFF
--- a/chrome/content/markdown-viewer.js
+++ b/chrome/content/markdown-viewer.js
@@ -16,7 +16,7 @@ if (!MarkdownViewer) {
 
 		onPageLoad: function(aEvent) {
 			var document = aEvent.originalTarget;
-			var markdownFileExtension = /\.m(arkdown|kdn?|d(o?wn)?)(#.*)?$/i;
+			var markdownFileExtension = /\.m(arkdown|kdn?|d(o?wn)?)(#.*)?(.*)$/i;
 
 			if (document.location.protocol !== "view-source:"
 				&& markdownFileExtension.test(document.location.href)) {


### PR DESCRIPTION
mardown.md?toto=tata is not detected as markdown file.
