### PR TITLE
Skip processing for files served with content-type of "text/html"

### DIFF
--- a/chrome/content/markdown-viewer.js
+++ b/chrome/content/markdown-viewer.js
@@ -72,7 +72,8 @@ if (!MarkdownViewer) {
 			var markdownFileExtension = /\.m(arkdown|kdn?|d(o?wn)?)(#.*)?(.*)$/i;
 
 			if (document.location.protocol !== "view-source:"
-				&& markdownFileExtension.test(document.location.href)) {
+				&& markdownFileExtension.test(document.location.href)
+				&& document.contentType !== "text/html") {
 
                 if (document.characterSet !== 'UTF-8') {
                     BrowserSetForcedCharacterSet('utf-8');


### PR DESCRIPTION
Github, Bitbucket, etc serve URLs with ".md" extension in their HTML-converted form.
E.g. https://github.com/Thiht/markdown-viewer/blob/master/README.md
