### PR TITLE
Change to text/plain to restore Linux rendering

### DIFF
--- a/components/x-genesis-rom-to-html-stream.js
+++ b/components/x-genesis-rom-to-html-stream.js
@@ -41,7 +41,7 @@ if (!MarkdownViewer.StreamConverter) {
 			this.data    = "";
 			this.uri     = aRequest.QueryInterface (Components.interfaces.nsIChannel).URI.spec;
 		    this.channel = aRequest;
-		    this.channel.contentType = "text/html";
+		    this.channel.contentType = "text/plain";
 		    this.listener.onStartRequest (this.channel, aContext);
 		},
 

--- a/components/x-markdown-to-html-stream.js
+++ b/components/x-markdown-to-html-stream.js
@@ -41,7 +41,7 @@ if (!MarkdownViewer.StreamConverter) {
 			this.data    = "";
 			this.uri     = aRequest.QueryInterface (Components.interfaces.nsIChannel).URI.spec;
 		    this.channel = aRequest;
-		    this.channel.contentType = "text/html";
+		    this.channel.contentType = "text/plain";
 		    this.listener.onStartRequest (this.channel, aContext);
 		},
 


### PR DESCRIPTION
I confirmed this works on Linux and @Thiht confirmed that it does not break Windows.
