### PR TITLE
Strictly match URLs with parameters

### DIFF
--- a/chrome/content/markdown-viewer.js
+++ b/chrome/content/markdown-viewer.js
@@ -64,7 +64,7 @@ if (!MarkdownViewer) {
 
 		onPageLoad: function(aEvent) {
 			const document = aEvent.originalTarget;
-			const markdownFileExtension = /\.m(arkdown|kdn?|d(o?wn)?)(#.*)?(.*)$/i;
+			const markdownFileExtension = /\.m(arkdown|kdn?|d(o?wn)?)(\?.*)?(#.*)?$/i;
 
 			if (document.location.protocol !== "view-source:" &&
 				markdownFileExtension.test(document.location.href) &&


### PR DESCRIPTION
Previously the trailing .* erroneously matched URLs like
https://iamnotmarkdown.mdnotmarkdown.bug.  Regression from
25d124bc6ec471b964be401d6013ff803d8e2ddd.  Fixes #51.