### PR TITLE
Associate text/x-markdown

### DIFF
--- a/chrome.manifest
+++ b/chrome.manifest
@@ -5,4 +5,5 @@ overlay chrome://browser/content/browser.xul chrome://markdown-viewer/content/ov
 
 component {2027cd20-b21a-11e3-a5e2-0800200c9a66} components/markdown-to-plain-stream.js
 contract @mozilla.org/streamconv;1?from=text/markdown&to=*/* {2027cd20-b21a-11e3-a5e2-0800200c9a66}
+contract @mozilla.org/streamconv;1?from=text/x-markdown&to=*/* {2027cd20-b21a-11e3-a5e2-0800200c9a66}
 


### PR DESCRIPTION
This allows markdown viewer to work correctly with Firefox 44.0b7 on
Ubuntu 14.04.  Fixes #54.  Regression from
1d9da0ecf4cfaad6f62ce1efb1744bade0d06efc.