### PR TITLE
Add SeaMonkey support

### DIFF
--- a/chrome.manifest
+++ b/chrome.manifest
@@ -2,6 +2,7 @@ content markdown-viewer chrome/content/
 skin markdown-viewer mdvskin chrome/skin/
 resource mdvskin chrome/skin/
 overlay chrome://browser/content/browser.xul chrome://markdown-viewer/content/overlay.xul
+overlay chrome://navigator/content/navigator.xul chrome://markdown-viewer/content/overlay.xul
 
 component {2027cd20-b21a-11e3-a5e2-0800200c9a66} components/markdown-to-plain-stream.js
 contract @mozilla.org/streamconv;1?from=text/markdown&to=*/* {2027cd20-b21a-11e3-a5e2-0800200c9a66}

--- a/install.rdf
+++ b/install.rdf
@@ -19,6 +19,15 @@
 			</Description>
 		</em:targetApplication>
 
+		<!-- SeaMonkey -->
+		<em:targetApplication>
+			<em:Description>
+				<em:id>{92650c4d-4b8e-4d2a-b7eb-24ecf4f6b63a}</em:id>
+				<em:minVersion>2.0</em:minVersion>
+				<em:maxVersion>2.42.*</em:maxVersion>
+			</em:Description>
+		</em:targetApplication>
+
 		<em:localized>
 			<Description>
 				<em:locale>en-US</em:locale>


### PR DESCRIPTION
Seems to work perfectly in SeaMonkey after adding navigator.xul to chrome.manifest and adding SeaMonkey to the install.rdf.
Tested on my own build of SeaMonkey 2.42 (= Firefox/Thunderbird 45.)